### PR TITLE
fix: import  class 'APIError' in handlers.py

### DIFF
--- a/www/handlers.py
+++ b/www/handlers.py
@@ -12,7 +12,7 @@ import markdown2
 from aiohttp import web
 
 from coroweb import get, post
-from apis import Page, APIValueError, APIResourceNotFoundError
+from apis import Page, APIValueError, APIResourceNotFoundError, APIError
 
 from models import User, Comment, Blog, next_id
 from config import configs


### PR DESCRIPTION
fix: if an email is registered, then prompt 'Email is already in use'.

in register page, if you input an email that has been registered, the website will prompt 'Email is already in use'.